### PR TITLE
Update operation id and summary handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# IntelliJ
+.idea

--- a/package-lock.json
+++ b/package-lock.json
@@ -900,6 +900,21 @@
         "node": ">=10"
       }
     },
+    "node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "peer": true,
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/mkdirp-promise": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-1.1.0.tgz",

--- a/templates/openapi3/main.dot
+++ b/templates/openapi3/main.dot
@@ -24,8 +24,8 @@
 {{?}}
 
 {{ for (var m in data.resource.methods) { }}
-{{ data.operationUniqueName = m; }}
 {{ data.method = data.resource.methods[m]; }}
+{{ data.operationUniqueName = data.method.operation.summary; }}
 {{ data.operationUniqueSlug = data.method.slug; }}
 {{ data.operation = data.method.operation; }}
 {{= data.templates.operation(data) }}

--- a/templates/openapi3/operation.dot
+++ b/templates/openapi3/operation.dot
@@ -1,7 +1,7 @@
 ## {{= data.operationUniqueName}}
 
-{{? data.operation.operationId}}
-<a id="opId{{=data.operation.operationId}}"></a>
+{{? data.operation.summary}}
+<a id="opId{{=data.operation.summary}}"></a>
 {{?}}
 
 {{ data.methodUpper = data.method.verb.toUpperCase(); }}
@@ -21,8 +21,6 @@
 {{?}}
 
 `{{= data.methodUpper}} {{=data.method.path}}`
-
-{{? data.operation.summary && !data.options.tocSummary}}*{{= data.operation.summary }}*{{?}}
 
 {{? data.operation.description}}{{= data.operation.description }}{{?}}
 


### PR DESCRIPTION
\+ hardenize/issues-eng#2505

This commit changes how the operation id and summary are handled in openapi3 templates - ids are now based on the operation's summary rather than its id. Additionally, the mkdirp package has been added and the .gitignore file has been updated to ignore IntelliJ configuration files.